### PR TITLE
Using the invoke call in method missing with the correct ref to args.

### DIFF
--- a/lib/jsonrpc/client.rb
+++ b/lib/jsonrpc/client.rb
@@ -69,7 +69,7 @@ module JSONRPC
 
     def method_missing(sym, *args, &block)
       if @alive
-        request = ::JSONRPC::Request.new(sym.to_s, args)
+        request = ::JSONRPC::Request.new(sym.to_s, *args)
         push_batch_request(request)
       else
         super
@@ -122,7 +122,7 @@ module JSONRPC
 
   class Client < Base
     def method_missing(method, *args, &block)
-      invoke(method, args)
+      invoke(method, *args)
     end
 
     def invoke(method, args, options = nil)

--- a/lib/jsonrpc/version.rb
+++ b/lib/jsonrpc/version.rb
@@ -1,3 +1,3 @@
 module JSONRPC
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end


### PR DESCRIPTION
`invoke` has to be called with `*args` to have the expected behaviour for method missing.
