### PR TITLE
fix validate response bug

### DIFF
--- a/lib/jsonrpc/client.rb
+++ b/lib/jsonrpc/client.rb
@@ -190,11 +190,9 @@ module JSONRPC
 
     def valid_response?(data)
       return false if !data.is_a?(::Hash)
-      return false if data['jsonrpc'] != ::JSONRPC::Base::JSON_RPC_VERSION
       return false if !data.has_key?('id')
-      return false if data.has_key?('error') && data.has_key?('result')
 
-      if data.has_key?('error')
+      if data['error']
         if !data['error'].is_a?(::Hash) || !data['error'].has_key?('code') || !data['error'].has_key?('message')
           return false
         end


### PR DESCRIPTION
Not sure what is the bitcoind rpc server response, but here is a response I got from an altcoin.
{
    "result": 0.00000000,
    "error": null,
    "id": 852040828182
}
With this response, the code will raise the exception: JSONRPC::Error::InvalidResponse
This commit will prevent that.
