### PR TITLE
Better server error - added code and response_error methods

### DIFF
--- a/lib/jsonrpc/error.rb
+++ b/lib/jsonrpc/error.rb
@@ -13,11 +13,11 @@ module JSONRPC
     end
 
     class ServerError < StandardError
-      attr_reader :code, :message
+      attr_reader :code, :response_error
 
       def initialize(code, message)
         @code = code
-        @message = message
+        @response_error = message
         super("Server error #{code}: #{message}")
       end
     end


### PR DESCRIPTION
It's needed to access error 'code' in error handling code. Now I should parse string message to extract code from it. This change provides access  to code directly from ServerError instance
