### PR TITLE
Explicitly require URI to ensure it is loaded

### DIFF
--- a/lib/jsonrpc/client.rb
+++ b/lib/jsonrpc/client.rb
@@ -1,5 +1,6 @@
 require 'multi_json'
 require 'faraday'
+require 'uri'
 require 'jsonrpc/request'
 require 'jsonrpc/response'
 require 'jsonrpc/error'


### PR DESCRIPTION
In plain-ruby contexts, URI isn't loaded when you initialize a client without requiring it first. It's better to explicitly require to ensure that it is loaded when called in the initializer of JSONRPC::Client.