### PR TITLE
Batch requests now have send the correct meta data of the field JSON_…

### DIFF
--- a/lib/jsonrpc/request.rb
+++ b/lib/jsonrpc/request.rb
@@ -3,6 +3,7 @@ module JSONRPC
 
     attr_accessor :method, :params, :id
     def initialize(method, params, id = nil)
+      @jsonrpc = ::JSONRPC::Base::JSON_RPC_VERSION
       @method = method
       @params = params
       @id = id
@@ -10,7 +11,7 @@ module JSONRPC
 
     def to_h
       h = {
-        'jsonrpc' => '2.0',
+        'jsonrpc' => @jsonrpc,
         'method'  => @method
       }
       h.merge!('params' => @params) if !!@params && !params.empty?


### PR DESCRIPTION
Batch requests now have send the correct meta data of the field JSON_RPC_VERSION and thus don't cause the batch request to crash on sensetive servers.

Apparently the to_h and to_json method was never called on the request class and so the json version was never set.